### PR TITLE
Update to new way of doing things with js-builder

### DIFF
--- a/war/gulpfile.js
+++ b/war/gulpfile.js
@@ -20,7 +20,7 @@ builder.bundle('src/main/js/page-init.js')
 //
 builder.bundle('src/main/js/pluginSetupWizard.js')
     .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
-    .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3', {addDefaultCSS: true})
+    .withExternalModuleMapping('bootstrap-detached', 'core-assets/bootstrap:bootstrap3', {addDefaultCSS: true})
     .withExternalModuleMapping('handlebars', 'core-assets/handlebars:handlebars3')
     .less('src/main/less/pluginSetupWizard.less')
     .inDir('src/main/webapp/jsbundles');

--- a/war/package.json
+++ b/war/package.json
@@ -5,19 +5,20 @@
   "license": "MIT",
   "devDependencies": {
     "gulp": "^3.9.0",
-    "handlebars": "^3.0.3",
-    "hbsfy": "^2.4.1",
-    "jenkins-handlebars-rt": "^1.0.1",
     "@jenkins-cd/js-builder": "0.0.32",
     "@jenkins-cd/js-test": "1.1.2",
-    "@jenkins-cd/js-modules": "0.0.5",
     "jshint": "^2.9.2",
     "gulp-jshint": "^2.0.0"
   },
   "dependencies": {
-    "bootstrap-detached": "^3.3.5-v1",
-    "jenkins-js-modules": "^1.5.0",
+    "bootstrap-detached": "^3.3.4-v6",
+    "@jenkins-cd/js-modules": "0.0.5",
     "jquery-detached": "^2.1.4-v2",
-    "window-handle": "^1.0.0"
+    "window-handle": "^1.0.0",
+    "handlebars": "^4.0.5",
+    "moment": "^2.10.6"
+  },
+  "jenkinscd" : {
+    "extDependencies": ["bootstrap-detached", "handlebars", "moment"]
   }
 }

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -5,6 +5,8 @@
 // Require modules here, make sure they get browserify'd/bundled
 var jquery = require('jquery-detached');
 var bootstrap = require('bootstrap-detached');
+var handlebars = require('handlebars');
+var fs = require('fs');
 var jenkins = require('./util/jenkins');
 var pluginManager = require('./api/pluginManager');
 var securityConfig = require('./api/securityConfig');
@@ -106,18 +108,18 @@ var createPluginSetupWizard = function(appendTarget) {
 	});
 	
 	// Include handlebars templates here - explicitly require them and they'll be available by hbsfy as part of the bundle process
-	var errorPanel = require('./templates/errorPanel.hbs');
-	var loadingPanel = require('./templates/loadingPanel.hbs');
-	var welcomePanel = require('./templates/welcomePanel.hbs');
-	var progressPanel = require('./templates/progressPanel.hbs');
-	var pluginSuccessPanel = require('./templates/successPanel.hbs');
-	var pluginSelectionPanel = require('./templates/pluginSelectionPanel.hbs');
-	var setupCompletePanel = require('./templates/setupCompletePanel.hbs');
-	var proxyConfigPanel = require('./templates/proxyConfigPanel.hbs');
-	var firstUserPanel = require('./templates/firstUserPanel.hbs');
-	var offlinePanel = require('./templates/offlinePanel.hbs');
-	var pluginSetupWizard = require('./templates/pluginSetupWizard.hbs');
-	var incompleteInstallationPanel = require('./templates/incompleteInstallationPanel.hbs');
+	var errorPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/errorPanel.hbs', 'utf8'));
+	var loadingPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/loadingPanel.hbs', 'utf8'));
+	var welcomePanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/welcomePanel.hbs', 'utf8'));
+	var progressPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/progressPanel.hbs', 'utf8'));
+	var pluginSuccessPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/successPanel.hbs', 'utf8'));
+	var pluginSelectionPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/pluginSelectionPanel.hbs', 'utf8'));
+	var setupCompletePanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/setupCompletePanel.hbs', 'utf8'));
+	var proxyConfigPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/proxyConfigPanel.hbs', 'utf8'));
+	var firstUserPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/firstUserPanel.hbs', 'utf8'));
+	var offlinePanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/offlinePanel.hbs', 'utf8'));
+	var pluginSetupWizard = handlebars.compile(fs.readFileSync(__dirname + '/./templates/pluginSetupWizard.hbs', 'utf8'));
+	var incompleteInstallationPanel = handlebars.compile(fs.readFileSync(__dirname + '/./templates/incompleteInstallationPanel.hbs', 'utf8'));
 
 	// wrap calls with this method to handle generic errors returned by the plugin manager
 	var handleGenericError = function(success) {


### PR DESCRIPTION
This seems to fix the build issues. Something changed and `.hbs` is no longer being browserified automatically. The examples seem to indicate this is the correct way to include the files.